### PR TITLE
caddy-gen: fix uppercase url

### DIFF
--- a/caddy-gen/src/config.py
+++ b/caddy-gen/src/config.py
@@ -1,7 +1,7 @@
 BASES = {
     "siyuan": ['mirror.sjtu.edu.cn', 'ftp.sjtu.edu.cn', 'ftp6.sjtu.edu.cn', 'siyuan.internal.sjtug.org'],
     "zhiyuan": ['mirrors.sjtug.sjtu.edu.cn', 'zhiyuan.internal.sjtug.org'],
-    "local": ['localhost']
+    "local": [':80']
 }
 
 LUG_ADDR = 'lug:7001'

--- a/caddy/Caddyfile.local
+++ b/caddy/Caddyfile.local
@@ -1,0 +1,83 @@
+  {
+    key_type rsa4096
+}
+
+http://:80/ {
+    log {
+        output stdout
+        format single_field common_log  # log in v1 style
+    }
+    redir / https://:80/ 308
+}
+
+:80 {
+    log {
+        output stdout
+        format single_field common_log  # log in v1 style
+    }
+
+    file_server /* {
+        root /dists
+    }
+    rewrite /docs/* /  # for react app
+
+    reverse_proxy /lug/* lug:7001 {
+        header_down Access-Control-Allow-Origin *
+        header_down Access-Control-Request-Method GET
+    }
+
+    basicauth /monitor/* {
+        {$MONITOR_USER} {$MONITOR_PASSWORD_HASHED}
+    }
+    route /monitor/node_exporter/* {
+        uri strip_prefix /monitor/node_exporter
+        reverse_proxy 172.31.0.1:9100
+    }
+    route /monitor/cadvisor/* {
+        uri strip_prefix /monitor/cadvisor
+        reverse_proxy cadvisor:8080
+    }
+    route /monitor/lug/* {
+        uri strip_prefix /monitor/lug
+        reverse_proxy lug:8081
+    }
+    route /monitor/mirror-intel/* {
+        uri strip_prefix /monitor/mirror-intel
+        reverse_proxy mirror-intel:8000
+    }
+    route /monitor/docker-gcr/* {
+        uri strip_prefix /monitor/docker-gcr
+        reverse_proxy siyuan-gcr-registry:5001
+    }
+    route /monitor/docker-registry/* {
+        uri strip_prefix /monitor/docker-registry
+        reverse_proxy siyuan-docker-registry:5001
+    }
+
+    @hidden {
+        path */.*
+    }
+    respond @hidden 404
+    @reject_lug_api {
+        path /lug/v1/admin/*
+    }
+    respond @reject_lug_api 403
+
+    header * x-sjtug-mirror-id local
+    header /mirrorz/* Access-Control-Allow-Origin *
+    header /mirrorz/* Access-Control-Request-Method GET
+
+    redir /test /test/ 301
+    file_server /test/* browse {
+        root /srv
+        hide .*
+    }
+    redir /TEST /TEST/ 301
+    file_server /TEST/* browse {
+        root /srv
+        hide .*
+    }
+    @gzip_enabled
+    encode @gzip_enabled gzip zstd
+}
+

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -853,17 +853,17 @@ mirror.sjtu.edu.cn {
     redir /CTAN /CTAN/ 301
     route /CTAN/* {
         uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CTAN{uri} 302
     }
     redir /CPAN /CPAN/ 301
     route /CPAN/* {
         uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CPAN{uri} 302
     }
     redir /CRAN /CRAN/ 301
     route /CRAN/* {
         uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CRAN{uri} 302
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {
@@ -1793,17 +1793,17 @@ ftp.sjtu.edu.cn {
     redir /CTAN /CTAN/ 301
     route /CTAN/* {
         uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CTAN{uri} 302
     }
     redir /CPAN /CPAN/ 301
     route /CPAN/* {
         uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CPAN{uri} 302
     }
     redir /CRAN /CRAN/ 301
     route /CRAN/* {
         uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CRAN{uri} 302
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {
@@ -2733,17 +2733,17 @@ ftp6.sjtu.edu.cn {
     redir /CTAN /CTAN/ 301
     route /CTAN/* {
         uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CTAN{uri} 302
     }
     redir /CPAN /CPAN/ 301
     route /CPAN/* {
         uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CPAN{uri} 302
     }
     redir /CRAN /CRAN/ 301
     route /CRAN/* {
         uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CRAN{uri} 302
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {
@@ -3673,17 +3673,17 @@ siyuan.internal.sjtug.org {
     redir /CTAN /CTAN/ 301
     route /CTAN/* {
         uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CTAN{uri} 302
     }
     redir /CPAN /CPAN/ 301
     route /CPAN/* {
         uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CPAN{uri} 302
     }
     redir /CRAN /CRAN/ 301
     route /CRAN/* {
         uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+        redir * https://mirrors.sjtug.sjtu.edu.cn/CRAN{uri} 302
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -412,19 +412,19 @@ mirrors.sjtug.sjtu.edu.cn {
         redir * https://fonts.googleapis.com{uri} 302
     }
     redir /CTAN /CTAN/ 301
-    route /CTAN/* {
-        uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+    file_server /CTAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /CPAN /CPAN/ 301
-    route /CPAN/* {
-        uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+    file_server /CPAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /CRAN /CRAN/ 301
-    route /CRAN/* {
-        uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+    file_server /CRAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {
@@ -754,9 +754,6 @@ mirrors.sjtug.sjtu.edu.cn {
         not path /k8s.gcr.io/*
         not path /docker-registry/*
         not path /google-fonts/*
-        not path /CTAN/*
-        not path /CPAN/*
-        not path /CRAN/*
         not path /manjarostable/*
         not path /centos/*
         not path /debian/*
@@ -1177,19 +1174,19 @@ zhiyuan.internal.sjtug.org {
         redir * https://fonts.googleapis.com{uri} 302
     }
     redir /CTAN /CTAN/ 301
-    route /CTAN/* {
-        uri strip_prefix /CTAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
+    file_server /CTAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /CPAN /CPAN/ 301
-    route /CPAN/* {
-        uri strip_prefix /CPAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cpan{uri} 302
+    file_server /CPAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /CRAN /CRAN/ 301
-    route /CRAN/* {
-        uri strip_prefix /CRAN
-        redir * https://mirrors.sjtug.sjtu.edu.cn/cran{uri} 302
+    file_server /CRAN/* browse {
+        root /mnt
+        hide .*
     }
     redir /manjarostable /manjarostable/ 301
     route /manjarostable/* {
@@ -1519,9 +1516,6 @@ zhiyuan.internal.sjtug.org {
         not path /k8s.gcr.io/*
         not path /docker-registry/*
         not path /google-fonts/*
-        not path /CTAN/*
-        not path /CPAN/*
-        not path /CRAN/*
         not path /manjarostable/*
         not path /centos/*
         not path /debian/*

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,7 @@ services:
     caddy:
       volumes:
         - "/srv:/srv"
+        - "./caddy/Caddyfile.local:/etc/caddy/Caddyfile:ro"
     lug:
       volumes:
         - "./lug/config.local.yaml:/config.local.yaml:ro"

--- a/lug/config.local.yaml
+++ b/lug/config.local.yaml
@@ -21,13 +21,8 @@ repos:
     interval: 3600
     name: test
     path: /srv/test
-    subdomain: test.skyzh.xyz
     <<: *oneshot_common
-  - type: shell_script
-    script: /worker-script/test.sh
-    interval: 3600
-    name: test2
-    path: /srv/test2
-    subdomain: test2.skyzh.xyz
-    no_redir_http: true
-    <<: *oneshot_common
+  - type: external
+    name: TEST
+    path: /srv/TEST
+    disabled: true

--- a/lug/config.zhiyuan.yaml
+++ b/lug/config.zhiyuan.yaml
@@ -422,18 +422,15 @@ repos:
     target: https://fonts.googleapis.com
   - type: external
     name: CTAN
-    serve_mode: redir
-    target: https://mirrors.sjtug.sjtu.edu.cn/ctan
+    path: /mnt/CTAN
     disabled: true
   - type: external
     name: CPAN
-    serve_mode: redir
-    target: https://mirrors.sjtug.sjtu.edu.cn/cpan
+    path: /mnt/CPAN
     disabled: true
   - type: external
     name: CRAN
-    serve_mode: redir
-    target: https://mirrors.sjtug.sjtu.edu.cn/cran
+    path: /mnt/CRAN
     disabled: true
   - type: external
     name: manjarostable


### PR DESCRIPTION
Due to a bug in caddy which causes infinite redirection, we make a symbol link of CRAN to cran and serve it as file instead of 302 redirect.