### PR TITLE
caddy-gen: fix logging

### DIFF
--- a/caddy-gen/src/caddy-gen.py
+++ b/caddy-gen/src/caddy-gen.py
@@ -117,7 +117,7 @@ def gen_repos(base: str, repos: dict, first_site: bool, site: str) -> tuple[list
     file_server_nodes = []
     git_server_nodes = []
 
-    gzip_disabled_list = []
+    gzip_disabled_list = ["speedtest"]
 
     for repo_ in repos:
         repo = dict_to_repo(repo_)
@@ -158,11 +158,9 @@ def gen_repos(base: str, repos: dict, first_site: bool, site: str) -> tuple[list
     file_server_nodes += gzip_disabled
     file_server_nodes += gzip('@gzip_enabled')
 
-    outer_nodes += [
-        Node(f'http://{base}/speedtest', [
-            Node('redir / http://{base}/speedtest/ 308')
-        ]),
-        Node(f'http://{base}/speedtest/*', [
+    file_server_nodes += [
+        Node('redir /speedtest /speedtest/ 308'),
+        Node(f'route /speedtest/*', [
             Node('uri strip_prefix /speedtest'),
             Node(f'reverse_proxy {SPEEDTEST_ADDR}')
         ])

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -357,15 +357,6 @@ http://mirror.sjtu.edu.cn/fedora/* {
     header * x-sjtug-mirror-id siyuan
 }
 
-http://mirror.sjtu.edu.cn/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://mirror.sjtu.edu.cn/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
-}
-
 mirror.sjtu.edu.cn {
     log {
         output stdout
@@ -999,6 +990,7 @@ mirror.sjtu.edu.cn {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /homebrew-bottles/*
         not path /rust-static/*
         not path /pypi-packages/*
@@ -1089,6 +1081,11 @@ mirror.sjtu.edu.cn {
         not path /ctan/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 
 http://ftp.sjtu.edu.cn/ {
@@ -1422,15 +1419,6 @@ http://ftp.sjtu.edu.cn/fedora/* {
         format single_field common_log  # log in v1 style
     }
     header * x-sjtug-mirror-id siyuan
-}
-
-http://ftp.sjtu.edu.cn/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://ftp.sjtu.edu.cn/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
 }
 
 ftp.sjtu.edu.cn {
@@ -2066,6 +2054,7 @@ ftp.sjtu.edu.cn {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /homebrew-bottles/*
         not path /rust-static/*
         not path /pypi-packages/*
@@ -2156,6 +2145,11 @@ ftp.sjtu.edu.cn {
         not path /ctan/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 
 http://ftp6.sjtu.edu.cn/ {
@@ -2489,15 +2483,6 @@ http://ftp6.sjtu.edu.cn/fedora/* {
         format single_field common_log  # log in v1 style
     }
     header * x-sjtug-mirror-id siyuan
-}
-
-http://ftp6.sjtu.edu.cn/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://ftp6.sjtu.edu.cn/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
 }
 
 ftp6.sjtu.edu.cn {
@@ -3133,6 +3118,7 @@ ftp6.sjtu.edu.cn {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /homebrew-bottles/*
         not path /rust-static/*
         not path /pypi-packages/*
@@ -3223,6 +3209,11 @@ ftp6.sjtu.edu.cn {
         not path /ctan/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 
 http://siyuan.internal.sjtug.org/ {
@@ -3556,15 +3547,6 @@ http://siyuan.internal.sjtug.org/fedora/* {
         format single_field common_log  # log in v1 style
     }
     header * x-sjtug-mirror-id siyuan
-}
-
-http://siyuan.internal.sjtug.org/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://siyuan.internal.sjtug.org/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
 }
 
 siyuan.internal.sjtug.org {
@@ -4200,6 +4182,7 @@ siyuan.internal.sjtug.org {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /homebrew-bottles/*
         not path /rust-static/*
         not path /pypi-packages/*
@@ -4290,5 +4273,10 @@ siyuan.internal.sjtug.org {
         not path /ctan/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -168,15 +168,6 @@ http://mirrors.sjtug.sjtu.edu.cn/ctan/* {
     header * x-sjtug-mirror-id zhiyuan
 }
 
-http://mirrors.sjtug.sjtu.edu.cn/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://mirrors.sjtug.sjtu.edu.cn/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
-}
-
 mirrors.sjtug.sjtu.edu.cn {
     log {
         output stdout
@@ -816,6 +807,7 @@ mirrors.sjtug.sjtu.edu.cn {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /git/homebrew-core.git/*
         not path /git/homebrew-cask.git/*
         not path /git/brew.git/*
@@ -904,6 +896,11 @@ mirrors.sjtug.sjtu.edu.cn {
         not path /macports/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 
 http://zhiyuan.internal.sjtug.org/ {
@@ -1012,15 +1009,6 @@ http://zhiyuan.internal.sjtug.org/ctan/* {
         format single_field common_log  # log in v1 style
     }
     header * x-sjtug-mirror-id zhiyuan
-}
-
-http://zhiyuan.internal.sjtug.org/speedtest {
-    redir / http://{base}/speedtest/ 308
-}
-
-http://zhiyuan.internal.sjtug.org/speedtest/* {
-    uri strip_prefix /speedtest
-    reverse_proxy speedtest:8989
 }
 
 zhiyuan.internal.sjtug.org {
@@ -1662,6 +1650,7 @@ zhiyuan.internal.sjtug.org {
         }
     }
     @gzip_enabled {
+        not path /speedtest/*
         not path /git/homebrew-core.git/*
         not path /git/homebrew-cask.git/*
         not path /git/brew.git/*
@@ -1750,5 +1739,10 @@ zhiyuan.internal.sjtug.org {
         not path /macports/*
     }
     encode @gzip_enabled gzip zstd
+    redir /speedtest /speedtest/ 308
+    route /speedtest/* {
+        uri strip_prefix /speedtest
+        reverse_proxy speedtest:8989
+    }
 }
 


### PR DESCRIPTION
Adding speedtest causes all HTTP log disappear. This is because logging is not enabled for speedtest, thus not enabled for all HTTP sites.

We may also wait until https://github.com/caddyserver/caddy/pull/4028 is available, which greatly simplifies logging configuration.