### PR TITLE
docker-compose: lift limit for rsync disk IO

### DIFF
--- a/docker-compose.siyuan.yml
+++ b/docker-compose.siyuan.yml
@@ -152,14 +152,14 @@ services:
       weight: 10
       device_read_bps:
         - path: /dev/vdb
-          rate: '1mb'
+          rate: '10mb'
         - path: /dev/vdc
-          rate: '1mb'
+          rate: '10mb'
       device_read_iops:
         - path: /dev/vdb
-          rate: 24
+          rate: 20
         - path: /dev/vdc
-          rate: 24
+          rate: 20
 
   git-backend:
     container_name: siyuan-git-backend


### PR DESCRIPTION
From https://github.com/sjtug/mirror-docker-unified/issues/2, we observe about 30 IOPS and 40MB/s (rand) write performance on cloud disk. Based on the statistics, we may be able to give about 1/4 of the total bandwidth to the rsync service.