### PR TITLE
lug: enable kernel synchronize

### DIFF
--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -671,5 +671,4 @@ repos:
     serve_mode: mirror_intel
     interval: 86400
     name: kernel
-    disabled: true
     <<: *oneshot_common


### PR DESCRIPTION
After we fixed HTTP last-modified bug in mirror-clone, we could finally synchronize the kernel repo. Note that the issue is caused by the `#` symbol in the URL foundationally, and we should fix this later.