### PR TITLE
lug: update homebrew rsync endpoint

### DIFF
--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -226,7 +226,7 @@ repos:
     <<: *oneshot_common
   # homebrew-bottles
   - type: shell_script
-    script: /worker-script/mirror-clone-v2.sh --workers 4 --target-type s3 --s3-prefix homebrew-bottles/bottles --s3-buffer-path /var/cache --print-plan 100 rsync --http-base https://mirrors.ustc.edu.cn/homebrew-bottles/bottles --rsync-base rsync://mirrors.ustc.edu.cn/homebrew-bottles/bottles/
+    script: /worker-script/mirror-clone-v2.sh --workers 4 --target-type s3 --s3-prefix homebrew-bottles/bottles --s3-buffer-path /var/cache --print-plan 100 rsync --http-base https://mirrors.ustc.edu.cn/homebrew-bottles/bottles --rsync-base rsync://rsync.mirrors.ustc.edu.cn/homebrew-bottles/bottles/
     serve_mode: mirror_intel
     interval: 10800
     name: homebrew-bottles


### PR DESCRIPTION
USTC only makes rsync available at rsync.mirrors.ustc.edu.cn