### PR TITLE
caddy: bump version to 2.4.0

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:2.2.1
+FROM caddy:2.4.0
 
 ARG USE_SJTUG
 RUN if [ "$USE_SJTUG" = true ] ; then sed -i 's/http:\/\/dl-cdn.alpinelinux.org/http:\/\/mirrors.ustc.edu.cn/g' /etc/apk/repositories ; fi


### PR DESCRIPTION
Some changes to be done:
* `common_log` will be removed. We must migrate to JSON log. By migrating to JSON log,. we could also filter User-Agent in our ELK stack. https://github.com/caddyserver/caddy/issues/4148
* Use multi issuer support for `ftp.sjtu.edu.cn`, which will fallback to NIC's cert after Let's Encrypt fails. We won't need to use a separate PR to specify certs. https://caddyserver.com/docs/automatic-https#issuer-fallback