### PR TITLE
lug: change debian upstream

### DIFF
--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -28,7 +28,7 @@ repos:
   # debian
   - type: shell_script
     script: /worker-script/debian.sh
-    source: mirrors.sfo.kernel.org
+    source: sv.mirrors.kernel.org
     interval: 5400
     path: /srv/disk1/debian
     name: debian


### PR DESCRIPTION
`mirrors.sio.kernel.org` has been out of sync for 5 days.

```
Tue Apr 19 14:56:48 UTC 2022
Date: Tue, 19 Apr 2022 14:56:48 +0000
Date-Started: Tue, 19 Apr 2022 14:42:28 +0000
Archive serial: 2022041903
```

This PR switches our upstream to `sv.mirrors.kernel.org`, which is now the default resolved server for `mirrors.kernel.org` on our host.