### PR TITLE
lug: move flutter to siyuan

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -389,6 +389,11 @@ mirror.sjtu.edu.cn {
         root /srv/disk3
         hide .*
     }
+    redir /download.flutter.io /download.flutter.io/ 301
+    file_server /download.flutter.io/* browse {
+        root /srv/disk3
+        hide .*
+    }
     redir /debian /debian/ 301
     file_server /debian/* browse {
         root /srv/disk1
@@ -919,11 +924,6 @@ mirror.sjtu.edu.cn {
         uri strip_prefix /linuxliteos
         redir * https://mirrors.sjtug.sjtu.edu.cn/linuxliteos{uri} 302
     }
-    redir /download.flutter.io /download.flutter.io/ 301
-    route /download.flutter.io/* {
-        uri strip_prefix /download.flutter.io
-        redir * https://mirrors.sjtug.sjtu.edu.cn/download.flutter.io{uri} 302
-    }
     redir /google-fonts /google-fonts/ 301
     route /google-fonts/* {
         uri strip_prefix /google-fonts
@@ -1131,7 +1131,6 @@ mirror.sjtu.edu.cn {
         not path /git/opam-repository.git/*
         not path /git/qemu.git/*
         not path /linuxliteos/*
-        not path /download.flutter.io/*
         not path /google-fonts/*
         not path /CPAN/*
         not path /CRAN/*

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -383,11 +383,6 @@ mirrors.sjtug.sjtu.edu.cn {
         root /mnt
         hide .*
     }
-    redir /download.flutter.io /download.flutter.io/ 301
-    file_server /download.flutter.io/* browse {
-        root /mnt
-        hide .*
-    }
     redir /k8s.gcr.io /k8s.gcr.io/ 301
     route /k8s.gcr.io/* {
         uri strip_prefix /k8s.gcr.io
@@ -440,6 +435,11 @@ mirrors.sjtug.sjtu.edu.cn {
     route /archlinuxarm/* {
         uri strip_prefix /archlinuxarm
         redir * https://mirror.sjtu.edu.cn/archlinuxarm{uri} 302
+    }
+    redir /download.flutter.io /download.flutter.io/ 301
+    route /download.flutter.io/* {
+        uri strip_prefix /download.flutter.io
+        redir * https://mirror.sjtu.edu.cn/download.flutter.io{uri} 302
     }
     redir /debian /debian/ 301
     route /debian/* {
@@ -934,6 +934,7 @@ mirrors.sjtug.sjtu.edu.cn {
         not path /google-fonts/*
         not path /anaconda/*
         not path /archlinuxarm/*
+        not path /download.flutter.io/*
         not path /debian/*
         not path /debian-cd/*
         not path /debian-security/*

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -33,6 +33,14 @@ repos:
     path: /srv/disk3/archlinuxarm
     name: archlinuxarm
     exclude_hidden: true
+  # flutter
+  - type: shell_script
+    name: download.flutter.io
+    script: /worker-script/rsync.sh
+    path: /srv/disk3/download.flutter.io
+    interval: 7200
+    source: rsync://mirrors.tuna.tsinghua.edu.cn/flutter/download.flutter.io/
+    <<: *oneshot_common
   # debian
   - type: shell_script
     script: /worker-script/debian.sh

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -267,13 +267,6 @@ repos:
     path: /mnt/linuxliteos
     name: linuxliteos
     <<: *oneshot_common
-  - type: shell_script
-    name: download.flutter.io
-    script: /worker-script/rsync.sh
-    path: /mnt/download.flutter.io
-    interval: 7200
-    source: rsync://mirrors.tuna.tsinghua.edu.cn/flutter/download.flutter.io/
-    <<: *oneshot_common
   - type: external
     name: k8s.gcr.io
     proxy_to: gcr-registry:80


### PR DESCRIPTION
The disk of zhiyuan is full. Flutter mirror takes about 1T, so moving to siyuan to free some space.