### PR TITLE
lug: move fedora-secondary to disk3

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -124,7 +124,7 @@ http://mirror.sjtu.edu.cn/fedora-secondary {
 http://mirror.sjtu.edu.cn/fedora-secondary/* {
     encode /* gzip zstd
     file_server /* browse {
-        root /srv/disk1
+        root /srv/disk3
         hide .*
     }
     @hidden {
@@ -426,7 +426,7 @@ mirror.sjtu.edu.cn {
     }
     redir /fedora-secondary /fedora-secondary/ 301
     file_server /fedora-secondary/* browse {
-        root /srv/disk1
+        root /srv/disk3
         hide .*
     }
     redir /linuxmint /linuxmint/ 301

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -119,7 +119,7 @@ repos:
     script: /worker-script/rsync.sh
     source: rsync://download-ib01.fedoraproject.org/fedora-secondary/
     interval: 5000
-    path: /srv/disk1/fedora-secondary
+    path: /srv/disk3/fedora-secondary
     name: fedora-secondary
     rsync_extra_flags: --exclude "development/*" --exclude "extras/*" --exclude "*/debug/*"
     no_redir_http: true


### PR DESCRIPTION
Now that disk1 is full, I'm moving fedora-secondary (approximately 1T) to disk3. After that, both disk1 and disk3 should have about 1T left.