### PR TITLE
lug: move qt to s3

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -402,6 +402,10 @@ mirror.sjtu.edu.cn {
     route /opencloudos/* {
         reverse_proxy rsync-gateway:8000
     }
+    redir /qt /qt/ 301
+    route /qt/* {
+        reverse_proxy rsync-gateway:8000
+    }
     redir /debian /debian/ 301
     file_server /debian/* browse {
         root /srv/disk1
@@ -895,11 +899,6 @@ mirror.sjtu.edu.cn {
         uri strip_prefix /mongodb
         redir * https://mirrors.sjtug.sjtu.edu.cn/mongodb{uri} 302
     }
-    redir /qt /qt/ 301
-    route /qt/* {
-        uri strip_prefix /qt
-        redir * https://mirrors.sjtug.sjtu.edu.cn/qt{uri} 302
-    }
     redir /julia /julia/ 301
     route /julia/* {
         uri strip_prefix /julia
@@ -1048,6 +1047,7 @@ mirror.sjtu.edu.cn {
         not path /speedtest/*
         not path /raspberry-pi-os-images/*
         not path /opencloudos/*
+        not path /qt/*
         not path /mageia/*
         not path /homebrew-bottles/*
         not path /rust-static/*
@@ -1132,7 +1132,6 @@ mirror.sjtu.edu.cn {
         not path /mx-packages/*
         not path /packagist/*
         not path /mongodb/*
-        not path /qt/*
         not path /julia/*
         not path /emacs-elpa/*
         not path /julia-releases/*

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -80,31 +80,6 @@ packagist.mirrors.sjtug.sjtu.edu.cn {
     header * x-sjtug-mirror-id zhiyuan
 }
 
-http://mirrors.sjtug.sjtu.edu.cn/qt {
-    redir /qt /qt/ 301
-    log {
-        output stdout
-        format single_field common_log  # log in v1 style
-    }
-}
-
-http://mirrors.sjtug.sjtu.edu.cn/qt/* {
-    encode /* gzip zstd
-    file_server /* browse {
-        root /mnt
-        hide .*
-    }
-    @hidden {
-        path */.*
-    }
-    respond @hidden 404
-    log {
-        output stdout
-        format single_field common_log  # log in v1 style
-    }
-    header * x-sjtug-mirror-id zhiyuan
-}
-
 k8s-gcr-io.mirrors.sjtug.sjtu.edu.cn {
     log {
         output stdout
@@ -341,11 +316,6 @@ mirrors.sjtug.sjtu.edu.cn {
         root /mnt
         hide .*
     }
-    redir /qt /qt/ 301
-    file_server /qt/* browse {
-        root /mnt
-        hide .*
-    }
     redir /julia /julia/ 301
     file_server /julia/* browse {
         root /mnt
@@ -445,6 +415,11 @@ mirrors.sjtug.sjtu.edu.cn {
     route /opencloudos/* {
         uri strip_prefix /opencloudos
         redir * https://mirror.sjtu.edu.cn/opencloudos{uri} 302
+    }
+    redir /qt /qt/ 301
+    route /qt/* {
+        uri strip_prefix /qt
+        redir * https://mirror.sjtu.edu.cn/qt{uri} 302
     }
     redir /debian /debian/ 301
     route /debian/* {
@@ -948,6 +923,7 @@ mirrors.sjtug.sjtu.edu.cn {
         not path /archlinuxarm/*
         not path /archlinux-cn/*
         not path /opencloudos/*
+        not path /qt/*
         not path /debian/*
         not path /debian-cd/*
         not path /debian-security/*

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -65,6 +65,15 @@ repos:
     name: opencloudos
     serve_mode: rsync_gateway
     <<: *rsync_fetcher_common
+  # qt
+  - type: shell_script
+    script: /worker-script/rsync-fetcher.sh
+    source: rsync://master.qt.io/qt-all
+    interval: 6000
+    rsync_extra_flags: --exclude "snapshots/*"
+    name: qt
+    serve_mode: rsync_gateway
+    <<: *rsync_fetcher_common
   # debian
   - type: shell_script
     script: /worker-script/debian.sh

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -203,14 +203,6 @@ repos:
     name: mongodb
     <<: *oneshot_common
   - type: shell_script
-    script: /worker-script/rsync.sh
-    source: master.qt.io::qt-all
-    interval: 6000
-    path: /mnt/qt
-    name: qt
-    rsync_extra_flags: --exclude "snapshots/*"
-    no_redir_http: true
-  - type: shell_script
     script: julia -t auto /worker-script/zhiyuan/worker-script/julia.jl
     interval: 8000
     path: /mnt/julia
@@ -332,3 +324,13 @@ repos:
     serve_mode: ignore
     unified: disable
     name: .mirrorz
+  - type: shell_script
+    script: /worker-script/rsync.sh
+    source: master.qt.io::qt-all
+    interval: 6000
+    path: /mnt/qt
+    name: qt_rsync
+    rsync_extra_flags: --exclude "snapshots/*"
+    no_redir_http: true
+    serve_mode: ignore
+    unified: disable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
         - USE_SJTUG=true
         - CLONE_VERSION=v0.1.18
         - CLONE_V2_VERSION=v0.2.32
-        - RSYNC_SJTUG_VERSION=v0.2.4
+        - RSYNC_SJTUG_VERSION=v0.2.10
         - LUG_VERSION=v0.12.7
     expose:
       - 8081
@@ -89,7 +89,7 @@ services:
       context: ./rsync-gateway
       args:
         - USE_SJTUG=true
-        - RSYNC_SJTUG_VERSION=v0.2.4
+        - RSYNC_SJTUG_VERSION=v0.2.10
     networks:
       - ipv6-service-net
       - redis-net

--- a/lug/worker-script/rsync-fetcher.sh
+++ b/lug/worker-script/rsync-fetcher.sh
@@ -9,4 +9,4 @@ export RUST_BACKTRACE=1
 mkdir -p "${LUG_tmp_path}"
 
 timeout 4h /app/rsync-gc --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --keep "${LUG_keep}"
-timeout 4h /app/rsync-fetcher --src "${LUG_source}" --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --repository "${LUG_name}" --gateway-base "${LUG_gateway}/${LUG_name}" --tmp-path "${LUG_tmp_path}"
+timeout 4h /app/rsync-fetcher --src "${LUG_source}" --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --repository "${LUG_name}" --gateway-base "${LUG_gateway}/${LUG_name}" --tmp-path "${LUG_tmp_path}" ${LUG_rsync_extra_flags}

--- a/lug/worker-script/rsync-fetcher.sh
+++ b/lug/worker-script/rsync-fetcher.sh
@@ -8,5 +8,7 @@ export RUST_BACKTRACE=1
 
 mkdir -p "${LUG_tmp_path}"
 
-timeout 4h /app/rsync-gc --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --keep "${LUG_keep}"
-timeout 4h /app/rsync-fetcher --src "${LUG_source}" --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --repository "${LUG_name}" --gateway-base "${LUG_gateway}/${LUG_name}" --tmp-path "${LUG_tmp_path}" ${LUG_rsync_extra_flags}
+LUG_timeout="${LUG_timeout:-4h}"
+
+timeout $LUG_timeout /app/rsync-gc --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --keep "${LUG_keep}"
+timeout $LUG_timeout /app/rsync-fetcher --src "${LUG_source}" --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --repository "${LUG_name}" --gateway-base "${LUG_gateway}/${LUG_name}" --tmp-path "${LUG_tmp_path}" ${LUG_rsync_extra_flags}

--- a/rsync-gateway/config.siyuan.toml
+++ b/rsync-gateway/config.siyuan.toml
@@ -9,3 +9,8 @@ s3_website = "https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss
 redis = "redis://redis/"
 redis_namespace = "opencloudos"
 s3_website = "https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/rsync/opencloudos"
+
+[endpoints.qt]
+redis = "redis://redis/"
+redis_namespace = "qt"
+s3_website = "https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/rsync/qt"


### PR DESCRIPTION
Qt now takes up about 1.4T of space, and most of the traffic to Zhiyuan is to this repo. Since Zhiyuan is overloaded, I propose to serve Qt on S3 storage.

I will keep the Qt repository on Zhiyuan for a month as a backup. In case of problems, we can always undo the migration.