### PR TITLE
followups for qt-to-s3

### DIFF
--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -334,3 +334,4 @@ repos:
     no_redir_http: true
     serve_mode: ignore
     unified: disable
+    hidden: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         - CLONE_VERSION=v0.1.18
         - CLONE_V2_VERSION=v0.2.32
         - RSYNC_SJTUG_VERSION=v0.2.10
-        - LUG_VERSION=v0.12.7
+        - LUG_VERSION=v0.12.8
     expose:
       - 8081
       - 7001

--- a/lug/worker-script/rsync-fetcher.sh
+++ b/lug/worker-script/rsync-fetcher.sh
@@ -10,5 +10,5 @@ mkdir -p "${LUG_tmp_path}"
 
 LUG_timeout="${LUG_timeout:-4h}"
 
-timeout $LUG_timeout /app/rsync-gc --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --keep "${LUG_keep}"
-timeout $LUG_timeout /app/rsync-fetcher --src "${LUG_source}" --s3-url "${LUG_s3_api}" --s3-region "${LUG_s3_region}" --s3-bucket "${LUG_s3_bucket}" --s3-prefix "rsync/${LUG_name}" --redis "${LUG_redis}" --redis-namespace "${LUG_name}" --repository "${LUG_name}" --gateway-base "${LUG_gateway}/${LUG_name}" --tmp-path "${LUG_tmp_path}" ${LUG_rsync_extra_flags}
+eval timeout $LUG_timeout /app/rsync-gc --s3-url "\"${LUG_s3_api}\"" --s3-region "\"${LUG_s3_region}\"" --s3-bucket "\"${LUG_s3_bucket}\"" --s3-prefix "\"rsync/${LUG_name}\"" --redis "\"${LUG_redis}\"" --redis-namespace "\"${LUG_name}\"" --keep "\"${LUG_keep}\""
+eval timeout $LUG_timeout /app/rsync-fetcher --src "\"${LUG_source}\"" --s3-url "\"${LUG_s3_api}\"" --s3-region "\"${LUG_s3_region}\"" --s3-bucket "\"${LUG_s3_bucket}\"" --s3-prefix "\"rsync/${LUG_name}\"" --redis "\"${LUG_redis}\"" --redis-namespace "\"${LUG_name}\"" --repository "\"${LUG_name}\"" --gateway-base "\"${LUG_gateway}/${LUG_name}\"" --tmp-path "\"${LUG_tmp_path}\"" ${LUG_rsync_extra_flags}


### PR DESCRIPTION
1. hide qt_rsync from mirror site
2. handle bash escape correctly for rsync-fetcher > rsync_extra_flags