### PR TITLE
lug: apt mirror script

### DIFF
--- a/lug/Dockerfile
+++ b/lug/Dockerfile
@@ -51,6 +51,9 @@ RUN /app/build-script/from-cache.sh \
 COPY build-script/misc/ftpsync.patch .
 RUN git clone https://salsa.debian.org/mirror-team/archvsync.git && cd archvsync && git checkout 57af581ff28a452f053f40639721bb279e1f2cdb && git apply /app/ftpsync.patch
 
+# apt-mirror
+RUN apt-get install apt-mirror -y
+
 # general config
 RUN mkdir /root/.ssh && ssh-keyscan cran.r-project.org >> /root/.ssh/known_hosts
 RUN git config --global credential.helper store

--- a/lug/Dockerfile
+++ b/lug/Dockerfile
@@ -52,7 +52,9 @@ COPY build-script/misc/ftpsync.patch .
 RUN git clone https://salsa.debian.org/mirror-team/archvsync.git && cd archvsync && git checkout 57af581ff28a452f053f40639721bb279e1f2cdb && git apply /app/ftpsync.patch
 
 # apt-mirror
-RUN apt-get install apt-mirror -y
+RUN cd $(mktemp -d) && \
+    wget -O apt-mirror https://raw.githubusercontent.com/apt-mirror/apt-mirror/088fa51357602ed4cea263b8eeff5c5365fcac63/apt-mirror && \
+    install -m 755 apt-mirror /usr/bin/apt-mirror
 
 # general config
 RUN mkdir /root/.ssh && ssh-keyscan cran.r-project.org >> /root/.ssh/known_hosts

--- a/lug/worker-script/apt.sh
+++ b/lug/worker-script/apt.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+sanitise_uri() {
+  local url="${1}"
+  url="${url#*://}"          # Remove protocol
+  url="${url#*@}"            # Remove user auth
+  echo "${url}"
+}
+
+# Setup apt-mirror config
+cat <<EOF > "apt-mirror_$LUG_name.list"
+set base_path    	$LUG_apt_mirror_path/$LUG_name
+set mirror_path  	\$base_path/mirror
+set skel_path    	\$base_path/skel
+set var_path     	\$base_path/var
+set run_postmirror    	0
+set _autoclean 		1
+set defaultarch  	null
+EOF
+
+# LUG_source is the base path of all urls, add trailing slash
+LUG_source="${LUG_source%/}/"
+
+# LUG_arch is a comma separated list of architectures
+IFS="," read -r -a archs <<< "$LUG_arch"
+
+modules=()
+# LUG_repo is a comma separated list of (module:arch:components) tuples
+IFS=',' read -r -a repos <<< "$LUG_repo"
+for repo in "${repos[@]}"; do
+    IFS=':' read -r module dist components <<< "$repo"
+    module="${module# }"
+    modules+=("$module")
+    for arch in "${archs[@]}"; do
+	echo "deb-$arch $LUG_source$module $dist $components" >> "apt-mirror_$LUG_name.list"
+    done
+done
+
+IFS=" " read -r -a modules <<< "$(echo "${modules[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+for module in "${modules[@]}"; do
+    echo "clean $LUG_source$module" >> "apt-mirror_$LUG_name.list"
+done
+
+apt-mirror "apt-mirror_$LUG_name.list"
+
+if [ ! -d "$LUG_path" ]; then
+    rel_path=$(sanitise_uri "$LUG_source")
+    ln -s "$LUG_apt_mirror_path/$LUG_name/mirror/$rel_path" "$LUG_path"
+fi


### PR DESCRIPTION
As per https://github.com/sjtug/mirror-requests/issues/79#issuecomment-1573295585, we need an apt-mirror script to sync apt repositories from HTTP upstream.

An example config:
```yaml
source: https://apt.pop-os.org
name: popos
arch: all,arm64,amd64
repo: release:jammy:main,release:impish:main
path: /some/path/popos
apt_mirror_path: /some/path/apt_mirror_path
```

`mirror`, `skel` and `var` directories will be created under `apt_mirror_path`, and the `mirror` directory will be symlinked to `path`. `apt_mirror_path` should never be cleaned manually, which `apt-mirror` handles.

Potential problem: does Caddy follow root path symlink? Say caddy is serving `/some/path` while `/some/path` itself is a symlink to another directory.