### PR TITLE
Revert "Revert "lug: move qt back to block device (#401)" (#404)"

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -419,10 +419,6 @@ mirror.sjtu.edu.cn {
     route /opencloudos/* {
         reverse_proxy rsync-gateway:8000
     }
-    redir /qt /qt/ 301
-    route /qt/* {
-        reverse_proxy rsync-gateway:8000
-    }
     redir /debian /debian/ 301
     file_server /debian/* browse {
         root /srv/data32T
@@ -981,6 +977,11 @@ mirror.sjtu.edu.cn {
         uri strip_prefix /ctan
         redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
     }
+    redir /qt /qt/ 301
+    route /qt/* {
+        uri strip_prefix /qt
+        redir * https://mirrors.sjtug.sjtu.edu.cn/qt{uri} 302
+    }
 
     route /git/linuxbrew-core.git/* {
         reverse_proxy git-backend
@@ -1069,7 +1070,6 @@ mirror.sjtu.edu.cn {
         not path /packman/*
         not path /raspberry-pi-os-images/*
         not path /opencloudos/*
-        not path /qt/*
         not path /debian-cd/*
         not path /deepin-cd/*
         not path /docker-ce/*
@@ -1174,6 +1174,7 @@ mirror.sjtu.edu.cn {
         not path /CRAN/*
         not path /CTAN/*
         not path /ctan/*
+        not path /qt/*
     }
     encode @gzip_enabled gzip zstd
     redir /speedtest /speedtest/ 308

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -140,6 +140,31 @@ http://mirrors.sjtug.sjtu.edu.cn/ctan/* {
     header * x-sjtug-mirror-id zhiyuan
 }
 
+http://mirrors.sjtug.sjtu.edu.cn/qt {
+    redir /qt /qt/ 301
+    log {
+        output stdout
+        format single_field common_log  # log in v1 style
+    }
+}
+
+http://mirrors.sjtug.sjtu.edu.cn/qt/* {
+    encode /* gzip zstd
+    file_server /* browse {
+        root /mnt
+        hide .*
+    }
+    @hidden {
+        path */.*
+    }
+    respond @hidden 404
+    log {
+        output stdout
+        format single_field common_log  # log in v1 style
+    }
+    header * x-sjtug-mirror-id zhiyuan
+}
+
 http://mirrors.sjtug.sjtu.edu.cn/speedtest {
     redir /speedtest /speedtest/ 308
     log {
@@ -382,6 +407,11 @@ mirrors.sjtug.sjtu.edu.cn {
         root /mnt
         hide .*
     }
+    redir /qt /qt/ 301
+    file_server /qt/* browse {
+        root /mnt
+        hide .*
+    }
     redir /debian-cdimage /debian-cdimage/ 301
     route /debian-cdimage/* {
         uri strip_prefix /debian-cdimage
@@ -426,11 +456,6 @@ mirrors.sjtug.sjtu.edu.cn {
     route /opencloudos/* {
         uri strip_prefix /opencloudos
         redir * https://mirror.sjtu.edu.cn/opencloudos{uri} 302
-    }
-    redir /qt /qt/ 301
-    route /qt/* {
-        uri strip_prefix /qt
-        redir * https://mirror.sjtu.edu.cn/qt{uri} 302
     }
     redir /debian /debian/ 301
     route /debian/* {
@@ -958,7 +983,6 @@ mirrors.sjtug.sjtu.edu.cn {
         not path /archlinuxarm/*
         not path /archlinux-cn/*
         not path /opencloudos/*
-        not path /qt/*
         not path /debian/*
         not path /debian-cd/*
         not path /debian-security/*

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -121,16 +121,16 @@ repos:
     serve_mode: rsync_gateway
     <<: *rsync_fetcher_common
     <<: *oneshot_common
-  # qt
-  - type: shell_script
-    script: /worker-script/rsync-fetcher.sh
-    source: rsync://master.qt.io/qt-all
-    interval: 6000
-    rsync_extra_flags: --exclude "snapshots/*"
-    name: qt
-    serve_mode: rsync_gateway
-    <<: *rsync_fetcher_common
-    <<: *oneshot_common
+  # qt (s3)
+  # - type: shell_script
+  #   script: /worker-script/rsync-fetcher.sh
+  #   source: rsync://master.qt.io/qt-all
+  #   interval: 6000
+  #   rsync_extra_flags: --exclude "snapshots/*"
+  #   name: qt
+  #   serve_mode: rsync_gateway
+  #   <<: *rsync_fetcher_common
+  #   <<: *oneshot_common
   # debian
   - type: shell_script
     script: /worker-script/debian.sh

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -325,9 +325,9 @@ repos:
     source: master.qt.io::qt-all
     interval: 6000
     path: /mnt/qt
-    name: qt_rsync
+    name: qt
     rsync_extra_flags: --exclude "snapshots/*"
     no_redir_http: true
-    serve_mode: ignore
-    unified: disable
-    hidden: true
+    # serve_mode: ignore
+    # unified: disable
+    # hidden: true

--- a/rsync-gateway/config.siyuan.toml
+++ b/rsync-gateway/config.siyuan.toml
@@ -20,11 +20,6 @@ redis = "redis://redis/"
 redis_namespace = "opencloudos"
 s3_website = "https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/rsync/opencloudos"
 
-[endpoints.qt]
-redis = "redis://redis/"
-redis_namespace = "qt"
-s3_website = "https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/rsync/qt"
-
 [endpoints.debian-cd]
 redis = "redis://redis/"
 redis_namespace = "debian-cd"


### PR DESCRIPTION
This reverts commit a7a07aa85f95c4c03063ad659a3bf1328da1244e.

Unfortunately, the Qt repository's S3 version has been experiencing failures for six days. A thorough investigation is required to identify the root cause, with the primary suspect being the slow speed of metadata diffing and generation.

The issue can likely be resolved with the upcoming release of rsync-sjtug based on Postgres. Until then, we will not be reverting to S3 storage for this repository.