### PR TITLE
lug: add support of adhoc in mirrorz generation

### DIFF
--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -25,6 +25,11 @@ dummy:
     keep: 2
     partial: 5
 
+# adhoc settings for mirrorz.json generation
+mirrorz_adhoc:
+  homebrew-bottles:
+    url: "/homebrew-bottles/bottles"
+
 repos:
   # centos
   # - type: shell_script

--- a/lug/worker-script/mirrorz.py
+++ b/lug/worker-script/mirrorz.py
@@ -92,10 +92,14 @@ def main():
     mirrorz["info"] = []
     mirrors = []
     sources = {item["name"]: item.get("source", "") for item in lug["repos"]}
+    adhoc = lug.get("mirrorz_adhoc", {})
     for worker, param in summary["WorkerStatus"].items():
         if worker.startswith(".") or worker == 'sjtug-internal' or worker == 'test':
             continue
         mirror = mirror_item(worker, param, help_items, sources)
+        if worker in adhoc:
+            for key, value in adhoc[worker].items():
+                mirror[key] = value
         mirrors.append(mirror)
 
     link_to(lug, summary, mirrors, help_items, sources)


### PR DESCRIPTION
Trying to workaround https://github.com/mirrorz-org/mirrorz-help/issues/132.