### PR TITLE
lug: redirect julia to pku

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -984,7 +984,7 @@ https://mirror.sjtu.edu.cn {
     }
     redir /julia /julia/ 301
     handle_path /julia/* {
-        redir * https://mirrors.sjtug.sjtu.edu.cn/julia{uri} 302
+        redir * https://mirrors.pku.edu.cn/julia/{uri} 302
     }
     redir /emacs-elpa /emacs-elpa/ 301
     handle_path /emacs-elpa/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -177,6 +177,7 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /raspbian/*
         not path /parrot/*
         not path /raspberrypi/*
+        not path /julia/*
         not path /msys2/*
         not path /git/opam-repository.git/*
         not path /git/qemu.git/*
@@ -458,13 +459,8 @@ https://mirrors.sjtug.sjtu.edu.cn {
         respond @hidden 404
     }
     redir /julia /julia/ 301
-    handle /julia/* {
-        file_server browse {
-            root /mnt
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
+    handle_path /julia/* {
+        redir * https://mirrors.pku.edu.cn/julia/{uri} 302
     }
     redir /emacs-elpa /emacs-elpa/ 301
     handle /emacs-elpa/* {

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -199,11 +199,16 @@ repos:
     path: /mnt/mongodb
     name: mongodb
     <<: *oneshot_common
-  - type: shell_script
-    script: julia -t auto /worker-script/zhiyuan/worker-script/julia.jl
-    interval: 8000
-    path: /mnt/julia
+  # - type: shell_script
+  #   script: julia -t auto /worker-script/zhiyuan/worker-script/julia.jl
+  #   interval: 8000
+  #   path: /mnt/julia
+  #   name: julia
+  - type: external
     name: julia
+    serve_mode: redir
+    target: https://mirrors.pku.edu.cn/julia/
+    disabled: true
   - type: shell_script
     name: emacs-elpa
     script: /worker-script/rsync.sh


### PR DESCRIPTION
Due to the relatively low usage of the Julia repository in spite of its extraordinary size, we are considering deprecating it or serving it on a cache-by-demand basis.

To ensure a smoother transition, we will redirect this repository to PKU mirror service.