### PR TITLE
lug: fix openwrt upstream url

### DIFF
--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -406,7 +406,7 @@ repos:
   # openwrt
   - type: shell_script
     script: /worker-script/rsync.sh
-    source: rsync://downloads.openwrt.org/downloads/
+    source: rsync://rsync.openwrt.org/downloads/
     interval: 6900
     path: /srv/data32T/openwrt
     rsync_extra_flags: --exclude "index.html" --exclude "snapshots/*"


### PR DESCRIPTION
> 2023-12-18: We had to change the DNS name for rsync to rsync.openwrt.org because downloads.openwrt.org is now served by a CDN. Please update your mirror setup to use the new name.
>
> https://openwrt.org/downloads