### PR TITLE
rsyncd: disable reverse dns lookup

### DIFF
--- a/lug/Dockerfile
+++ b/lug/Dockerfile
@@ -6,7 +6,7 @@ RUN if [ "$USE_SJTUG" = true ] ; then sed -i 's/http:\/\/security.debian.org/htt
 
 WORKDIR /app
 RUN apt-get update && apt-get install rsync wget git jq curl unzip -y
-RUN apt-get install apt-transport-https ca-certificates -y
+RUN apt-get install apt-transport-https ca-certificates zlib1g-dev -y
 
 RUN mkdir build-script
 
@@ -70,6 +70,15 @@ RUN /app/build-script/from-cache.sh \
         https://github.com/sjtug/lug/releases/download/${LUG_VERSION}/lug.tar.gz \
         tmp.tar.gz \
             && tar -xvf tmp.tar.gz && rm tmp.tar.gz
+
+
+RUN mkdir /tmp/openssl \
+    && git clone --depth 1 --branch OpenSSL_1_1_1w https://github.com/openssl/openssl.git /tmp/openssl \
+    && cd /tmp/openssl/ && ./config shared zlib \
+    && make \
+    && make install \
+    && echo "/usr/local/lib" > /etc/ld.so.conf.d/openssl-1.1.conf \
+    && ldconfig -v
 
 ARG CLONE_VERSION
 RUN /app/build-script/from-cache.sh \

--- a/rsyncd/rsyncd.siyuan.conf
+++ b/rsyncd/rsyncd.siyuan.conf
@@ -4,6 +4,7 @@ max connections = 4
 refuse options = checksum
 strict modes = no
 motd file = /etc/rsync/motd
+reverse lookup = no
 
 [fedora-secondary]
 path = /srv/data55T/fedora-secondary

--- a/rsyncd/rsyncd.zhiyuan.conf
+++ b/rsyncd/rsyncd.zhiyuan.conf
@@ -4,6 +4,7 @@ max connections = 4
 refuse options = checksum
 strict modes = no
 motd file = /etc/rsync/motd
+reverse lookup = no
 
 [qt]
 path = /mnt/qt


### PR DESCRIPTION
Current settings produces logs below:

```
siyuan-rsyncd  | 2025/08/26 03:19:35 [22457] name lookup failed for 172.19.0.1: Name or service not known
siyuan-rsyncd  | 2025/08/26 03:19:35 [22457] connect from UNKNOWN (172.19.0.1)
```

Disable rDNS lookup to make log clean.