### PR TITLE
Recent mirror fixes @ 20260528

### DIFF
--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -426,7 +426,6 @@ https://mirror.sjtu.edu.cn {
         not path /CRAN/*
         not path /CTAN/*
         not path /ctan/*
-        not path /qt/*
     }
     encode @gzip_enabled gzip zstd
 
@@ -525,6 +524,15 @@ https://mirror.sjtu.edu.cn {
     redir /opencloudos /opencloudos/ 301
     handle /opencloudos/* {
         reverse_proxy rsync-gateway:8000
+    }
+    redir /qt /qt/ 301
+    handle /qt/* {
+        file_server browse {
+            root /srv/data55T
+            hide .*
+        }
+        @hidden path */.*
+        respond @hidden 404
     }
     redir /debian /debian/ 301
     handle /debian/* {
@@ -1125,10 +1133,6 @@ https://mirror.sjtu.edu.cn {
     redir /ctan /ctan/ 301
     handle_path /ctan/* {
         redir * https://mirrors.sjtug.sjtu.edu.cn/ctan{uri} 302
-    }
-    redir /qt /qt/ 301
-    handle_path /qt/* {
-        redir * https://mirrors.sjtug.sjtu.edu.cn/qt{uri} 302
     }
 
     redir /git/homebrew-services.git /git/homebrew-services.git/ 301

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -936,24 +936,6 @@ https://mirror.sjtu.edu.cn {
         @hidden path */.*
         respond @hidden 404
     }
-    redir /ubuntukylin-cdimage /ubuntukylin-cdimage/ 301
-    handle /ubuntukylin-cdimage/* {
-        file_server browse {
-            root /srv/data55T
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
-    }
-    redir /ubuntukylin /ubuntukylin/ 301
-    handle /ubuntukylin/* {
-        file_server browse {
-            root /srv/data55T
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
-    }
     redir /zorinos-isos /zorinos-isos/ 301
     handle /zorinos-isos/* {
         file_server browse {

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -78,7 +78,6 @@ http://mirror.sjtu.edu.cn {
         not path /fedora/epel/*
         not path /opensuse/*
         not path /remi/*
-        not path /ubuntu/*
         not path /openeuler/*
         not path /fedora/*
     }
@@ -134,10 +133,6 @@ http://mirror.sjtu.edu.cn {
     redir /remi /remi/ 301
     handle_path /remi/* {
         redir * {scheme}://ftp.sjtu.edu.cn/remi{uri} 302
-    }
-    redir /ubuntu /ubuntu/ 301
-    handle_path /ubuntu/* {
-        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
     }
     redir /ubuntu-ports /ubuntu-ports/ 301
     handle /ubuntu-ports/* {
@@ -311,7 +306,6 @@ https://mirror.sjtu.edu.cn {
         not path /mx-packages/*
         not path /openvz/*
         not path /remi/*
-        not path /ubuntu/*
         not path /ubuntu-cdimage/*
         not path /homebrew-bottles/*
         not path /rust-static/*
@@ -631,8 +625,13 @@ https://mirror.sjtu.edu.cn {
         respond @hidden 404
     }
     redir /ubuntu /ubuntu/ 301
-    handle_path /ubuntu/* {
-        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
+    handle /ubuntu/* {
+        file_server browse {
+            root /srv/data55T
+            hide .*
+        }
+        @hidden path */.*
+        respond @hidden 404
     }
     redir /ubuntu-releases /ubuntu-releases/ 301
     handle /ubuntu-releases/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -763,7 +763,7 @@ https://mirrors.sjtug.sjtu.edu.cn {
     }
     redir /ubuntu /ubuntu/ 301
     handle_path /ubuntu/* {
-        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
+        redir * https://mirror.sjtu.edu.cn/ubuntu{uri} 302
     }
     redir /ubuntu-releases /ubuntu-releases/ 301
     handle_path /ubuntu-releases/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -263,6 +263,7 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /archlinuxarm/*
         not path /archlinux-cn/*
         not path /opencloudos/*
+        not path /qt/*
         not path /debian/*
         not path /debian-cd/*
         not path /debian-security/*
@@ -618,15 +619,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
         @hidden path */.*
         respond @hidden 404
     }
-    redir /qt /qt/ 301
-    handle /qt/* {
-        file_server browse {
-            root /mnt
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
-    }
     redir /keyarchos /keyarchos/ 301
     handle_path /keyarchos/* {
         redir * https://mirror.sjtu.edu.cn/keyarchos{uri} 302
@@ -690,6 +682,10 @@ https://mirrors.sjtug.sjtu.edu.cn {
     redir /opencloudos /opencloudos/ 301
     handle_path /opencloudos/* {
         redir * https://mirror.sjtu.edu.cn/opencloudos{uri} 302
+    }
+    redir /qt /qt/ 301
+    handle_path /qt/* {
+        redir * https://mirror.sjtu.edu.cn/qt{uri} 302
     }
     redir /debian /debian/ 301
     handle_path /debian/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -351,8 +351,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /git/linux.git/*
         not path /raspbian-addons/*
         not path /OpenBSD/*
-        not path /ubuntukylin-cdimage/*
-        not path /ubuntukylin/*
         not path /zorinos-isos/*
         not path /ubuntu-cloud-images/*
         not path /debian-ports/*
@@ -994,14 +992,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
     redir /OpenBSD /OpenBSD/ 301
     handle_path /OpenBSD/* {
         redir * https://mirror.sjtu.edu.cn/OpenBSD{uri} 302
-    }
-    redir /ubuntukylin-cdimage /ubuntukylin-cdimage/ 301
-    handle_path /ubuntukylin-cdimage/* {
-        redir * https://mirror.sjtu.edu.cn/ubuntukylin-cdimage{uri} 302
-    }
-    redir /ubuntukylin /ubuntukylin/ 301
-    handle_path /ubuntukylin/* {
-        redir * https://mirror.sjtu.edu.cn/ubuntukylin{uri} 302
     }
     redir /zorinos-isos /zorinos-isos/ 301
     handle_path /zorinos-isos/* {

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -94,7 +94,7 @@ repos:
     name: anthon
     script: /worker-script/rsync.sh
     interval: 5601
-    source: rsync://repo.aosc.io/anthon
+    source: rsync://repo-us.aosc.io/anthon
     path: /srv/data55T/anthon
     show_hidden: /anthon/.repotest /anthon/.repotest.sha256sum
     <<:

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -408,7 +408,7 @@ repos:
   # ubuntu-ports
   - type: shell_script
     script: /worker-script/ubuntu-debian-rsync.sh
-    source: rsync://ports.ubuntu.com/ubuntu-ports/
+    source: rsync://rsync.ports.ubuntu.com/ubuntu-ports/
     interval: 7800
     path: /srv/data55T/ubuntu-ports
     name: ubuntu-ports

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -200,16 +200,14 @@ repos:
     <<:
       - *rsync_fetcher_common
       - *oneshot_common
-    ## qt
-    #- type: shell_script
-    #  script: /worker-script/rsync-fetcher.sh
-    #  source: rsync://master.qt.io/qt-all
-    #  interval: 6000
-    #  rsync_extra_flags: --exclude "snapshots/*"
-    #  name: qt
-    #  serve_mode: rsync_gateway
-    #  <<: *rsync_fetcher_common
-    #  <<: *oneshot_common
+  # qt
+  - type: shell_script
+    script: /worker-script/rsync.sh
+    source: master.qt.io::qt-all
+    interval: 6000
+    path: /srv/data55T/qt
+    name: qt
+    rsync_extra_flags: --exclude "snapshots/*"
   # debian
   - type: shell_script
     script: /worker-script/debian.sh

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -381,12 +381,13 @@ repos:
     rsync_extra_flags: --exclude "termux-main-21"
     <<:
       - *oneshot_common
-  #ubuntu
+  # ubuntu
   - type: external
+    script: /worker-script/ubuntu-debian-rsync.sh
+    source: rsync://rsync.archive.ubuntu.com/ubuntu/
+    interval: 24900
+    path: /srv/data55T/ubuntu
     name: ubuntu
-    serve_mode: redir
-    target: "{scheme}://ftp.sjtu.edu.cn/ubuntu/"
-    no_redir_http: true
     <<:
       - *oneshot_common
   # ubuntu-releases

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -921,24 +921,6 @@ repos:
       - *oneshot_common
   - type: shell_script
     script: /worker-script/rsync.sh
-    source: rsync://cdimage.ubuntukylin.com/releases/
-    interval: 86400
-    path: /srv/data55T/ubuntukylin-cdimage
-    name: ubuntukylin-cdimage
-    rsync_extra_flags: --exclude "professional/"
-    <<:
-      - *oneshot_common
-  - type: shell_script
-    script: /worker-script/rsync.sh
-    source: rsync://archive.ubuntukylin.com/ubuntukylin/
-    interval: 6000
-    path: /srv/data55T/ubuntukylin
-    name: ubuntukylin
-    rsync_extra_flags: --exclude "*partner*/"
-    <<:
-      - *oneshot_common
-  - type: shell_script
-    script: /worker-script/rsync.sh
     source: rsync://mirror.zorinos.com/isos/
     interval: 86400
     path: /srv/data55T/zorinos-isos

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -366,13 +366,6 @@ repos:
     serve_mode: ignore
     unified: disable
     name: .mirrorz
-  - type: shell_script
-    script: /worker-script/rsync.sh
-    source: master.qt.io::qt-all
-    interval: 6000
-    path: /mnt/qt
-    name: qt
-    rsync_extra_flags: --exclude "snapshots/*"
     # no_redir_http: true
     # serve_mode: ignore
     # unified: disable

--- a/rsyncd/rsyncd.siyuan.conf
+++ b/rsyncd/rsyncd.siyuan.conf
@@ -16,6 +16,12 @@ path = /srv/data55T/openeuler
 comment = "openEuler"
 read only = true
 
+[qt]
+path = /srv/data55T/qt
+comment = "Qt"
+read only = true
+
+
 [termux]
 path = /srv/data55T/termux
 comment = "Termux packages"

--- a/rsyncd/rsyncd.zhiyuan.conf
+++ b/rsyncd/rsyncd.zhiyuan.conf
@@ -6,11 +6,6 @@ strict modes = no
 motd file = /etc/rsync/motd
 reverse lookup = no
 
-[qt]
-path = /mnt/qt
-comment = "Qt"
-read only = true
-
 [raspbian]
 path = /mnt/raspbian
 comment = "Raspbian"


### PR DESCRIPTION
Changes:

- Qt: move from Zhiyuan to Siyuan
- anthon: update upstream URL
- ubuntu-ports: update upstream URL
- ubuntukylin{,-cdimage}: drop
- ubuntu: serve on local storage

TODO:

- [ ] fix dart-pub on mirror-clone (force sending request to upstream `/api/packages`)
- Move back from redir to local storage for several mirrors:
  - [ ] fedora
  - [ ] archlinux