### PR TITLE
Recent mirror fixes @ 20260624

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .ruff_cache/
 venv/
 */.venv
+.pre-commit-config.flake.yaml

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -78,6 +78,7 @@ http://mirror.sjtu.edu.cn {
         not path /fedora/epel/*
         not path /opensuse/*
         not path /remi/*
+        not path /ubuntu/*
         not path /openeuler/*
         not path /fedora/*
     }
@@ -133,6 +134,10 @@ http://mirror.sjtu.edu.cn {
     redir /remi /remi/ 301
     handle_path /remi/* {
         redir * {scheme}://ftp.sjtu.edu.cn/remi{uri} 302
+    }
+    redir /ubuntu /ubuntu/ 301
+    handle_path /ubuntu/* {
+        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
     }
     redir /ubuntu-ports /ubuntu-ports/ 301
     handle /ubuntu-ports/* {
@@ -306,6 +311,7 @@ https://mirror.sjtu.edu.cn {
         not path /mx-packages/*
         not path /openvz/*
         not path /remi/*
+        not path /ubuntu/*
         not path /ubuntu-cdimage/*
         not path /homebrew-bottles/*
         not path /rust-static/*
@@ -624,13 +630,8 @@ https://mirror.sjtu.edu.cn {
         respond @hidden 404
     }
     redir /ubuntu /ubuntu/ 301
-    handle /ubuntu/* {
-        file_server browse {
-            root /srv/data55T
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
+    handle_path /ubuntu/* {
+        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
     }
     redir /ubuntu-releases /ubuntu-releases/ 301
     handle /ubuntu-releases/* {

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -311,7 +311,6 @@ https://mirror.sjtu.edu.cn {
         not path /rust-static/*
         not path /pypi-packages/*
         not path /dart-pub/*
-        not path /pytorch-wheels/*
         not path /crates.io/*
         not path /flutter_infra/*
         not path /ghcup/*
@@ -687,10 +686,6 @@ https://mirror.sjtu.edu.cn {
     }
     redir /dart-pub /dart-pub/ 301
     handle /dart-pub/* {
-        reverse_proxy mirror-intel:8000
-    }
-    redir /pytorch-wheels /pytorch-wheels/ 301
-    handle /pytorch-wheels/* {
         reverse_proxy mirror-intel:8000
     }
     redir /crates.io /crates.io/ 301

--- a/caddy/Caddyfile.siyuan
+++ b/caddy/Caddyfile.siyuan
@@ -289,7 +289,6 @@ https://mirror.sjtu.edu.cn {
         not path /racket/*
         not path /bmclapi/*
         not path /alhp/*
-        not path /nspawn/*
         not path /leopardsh/*
         not path /endeavouros/*
         not path /debian-cdimage/*
@@ -442,10 +441,6 @@ https://mirror.sjtu.edu.cn {
     }
     redir /alhp /alhp/ 301
     handle /alhp/* {
-        reverse_proxy rsync-gateway:8000
-    }
-    redir /nspawn /nspawn/ 301
-    handle /nspawn/* {
         reverse_proxy rsync-gateway:8000
     }
     redir /anthon /anthon/ 301
@@ -750,15 +745,6 @@ https://mirror.sjtu.edu.cn {
     redir /github/Office-Tool /github/Office-Tool/ 301
     handle_path /github/Office-Tool/* {
         redir * /github-release/YerongAI/Office-Tool/releases/download/?mirror_intel_list 302
-    }
-    redir /sites/tldp.org /sites/tldp.org/ 301
-    handle /sites/tldp.org/* {
-        file_server browse {
-            root /srv/data55T
-            hide .*
-        }
-        @hidden path */.*
-        respond @hidden 404
     }
     redir /nix-channels/store /nix-channels/store/ 301
     handle /nix-channels/store/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -251,7 +251,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /racket/*
         not path /bmclapi/*
         not path /alhp/*
-        not path /nspawn/*
         not path /anthon/*
         not path /leopardsh/*
         not path /endeavouros/*
@@ -313,7 +312,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /github/rubyinstaller2/*
         not path /github/PowerShell/*
         not path /github/Office-Tool/*
-        not path /sites/tldp.org/*
         not path /nix-channels/store/*
         not path /guix/*
         not path /guix-bordeaux/*
@@ -632,10 +630,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
     handle_path /alhp/* {
         redir * https://mirror.sjtu.edu.cn/alhp{uri} 302
     }
-    redir /nspawn /nspawn/ 301
-    handle_path /nspawn/* {
-        redir * https://mirror.sjtu.edu.cn/nspawn{uri} 302
-    }
     redir /anthon /anthon/ 301
     handle_path /anthon/* {
         redir * https://mirror.sjtu.edu.cn/anthon{uri} 302
@@ -851,10 +845,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
     redir /github/Office-Tool /github/Office-Tool/ 301
     handle_path /github/Office-Tool/* {
         redir * /github-release/YerongAI/Office-Tool/releases/download/?mirror_intel_list 302
-    }
-    redir /sites/tldp.org /sites/tldp.org/ 301
-    handle_path /sites/tldp.org/* {
-        redir * https://mirror.sjtu.edu.cn/sites/tldp.org{uri} 302
     }
     redir /nix-channels/store /nix-channels/store/ 301
     handle /nix-channels/store/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -762,7 +762,7 @@ https://mirrors.sjtug.sjtu.edu.cn {
     }
     redir /ubuntu /ubuntu/ 301
     handle_path /ubuntu/* {
-        redir * https://mirror.sjtu.edu.cn/ubuntu{uri} 302
+        redir * {scheme}://ftp.sjtu.edu.cn/ubuntu/{uri} 302
     }
     redir /ubuntu-releases /ubuntu-releases/ 301
     handle_path /ubuntu-releases/* {

--- a/caddy/Caddyfile.zhiyuan
+++ b/caddy/Caddyfile.zhiyuan
@@ -293,7 +293,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
         not path /rust-static/*
         not path /pypi-packages/*
         not path /dart-pub/*
-        not path /pytorch-wheels/*
         not path /crates.io/*
         not path /flutter_infra/*
         not path /ghcup/*
@@ -799,10 +798,6 @@ https://mirrors.sjtug.sjtu.edu.cn {
     }
     redir /dart-pub /dart-pub/ 301
     handle /dart-pub/* {
-        reverse_proxy mirror-intel:8000
-    }
-    redir /pytorch-wheels /pytorch-wheels/ 301
-    handle /pytorch-wheels/* {
         reverse_proxy mirror-intel:8000
     }
     redir /crates.io /crates.io/ 301

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -169,7 +169,7 @@ repos:
     name: raspberry-pi-os-images
     script: /worker-script/rsync-fetcher.sh
     interval: 10801
-    source: rsync://mirrors6.tuna.tsinghua.edu.cn/raspberry-pi-os-images/
+    source: rsync://mirrors.tuna.tsinghua.edu.cn/raspberry-pi-os-images/
     serve_mode: rsync_gateway
     <<:
       - *rsync_fetcher_common
@@ -211,7 +211,7 @@ repos:
   # debian
   - type: shell_script
     script: /worker-script/debian.sh
-    source: mirrors6.tuna.tsinghua.edu.cn
+    source: mirrors.tuna.tsinghua.edu.cn
     interval: 5400
     path: /srv/data55T/debian
     name: debian
@@ -254,7 +254,7 @@ repos:
   - type: shell_script
     name: docker-ce
     script: /worker-script/rsync-fetcher.sh
-    source: rsync://mirrors6.tuna.tsinghua.edu.cn/docker-ce/
+    source: rsync://mirrors.tuna.tsinghua.edu.cn/docker-ce/
     interval: 4900
     serve_mode: rsync_gateway
     no_redir_http: true
@@ -812,7 +812,7 @@ repos:
     name: bioconductor
     script: /worker-script/rsync-fetcher.sh
     interval: 40801
-    source: rsync://mirrors6.tuna.tsinghua.edu.cn/bioconductor/
+    source: rsync://mirrors.tuna.tsinghua.edu.cn/bioconductor/
     serve_mode: rsync_gateway
     <<:
       - *rsync_fetcher_common

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -471,14 +471,9 @@ repos:
     name: dart-pub
     <<:
       - *oneshot_common
-  # pytorch-wheels
-  - type: shell_script
-    script: /app/mirror-clone --concurrent_resolve 64 --workers 4 pytorch_wheels --target http://mirror-intel:8000/pytorch-wheels
-    serve_mode: mirror_intel
-    interval: 4900
-    name: pytorch-wheels
-    <<:
-      - *oneshot_common
+  # pytorch-wheels: served on-demand by mirror-intel
+  # (removed v1 mirror-clone proactive sync — torch_stable.html is legacy,
+  #  modern pytorch uses PEP 503 per-CUDA indexes that mirror-intel handles)
   # crates.io
   - type: shell_script
     script: /worker-script/mirror-clone-v2.sh --workers 4 --target-type s3 --s3-prefix crates.io/crates --s3-buffer-path /var/cache --print-plan 100 crates-io

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -79,16 +79,6 @@ repos:
     <<:
       - *rsync_fetcher_common
       - *oneshot_common
-  # nspawn
-  - type: shell_script
-    name: nspawn
-    script: /worker-script/rsync-fetcher.sh
-    interval: 6901
-    source: rsync://hub.nspawn.org/containers
-    serve_mode: rsync_gateway
-    <<:
-      - *rsync_fetcher_common
-      - *oneshot_common
   # anthon
   - type: shell_script
     name: anthon
@@ -659,14 +649,6 @@ repos:
     name: github/Office-Tool
     target: /github-release/YerongAI/Office-Tool/releases/download/?mirror_intel_list
     serve_mode: redir_force
-    <<:
-      - *oneshot_common
-  - type: shell_script
-    script: /worker-script/rsync.sh
-    source: ftp.ibiblio.org::ldp_mirror
-    interval: 5800
-    path: /srv/data55T/sites/tldp.org
-    name: sites/tldp.org
     <<:
       - *oneshot_common
   - type: shell_script

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -147,7 +147,7 @@ repos:
     source: https://apt.pop-os.org
     arch: "all,arm64,amd64,i386,src"
     # REMARK generate this list by script/popos_dists.sh
-    repo: "proprietary:bionic:main,proprietary:disco:main,proprietary:eoan:main,proprietary:focal:main,proprietary:groovy:main,proprietary:hirsute:main,proprietary:impish:main,proprietary:jammy:main,proprietary:noble:main,release:impish:main,release:jammy:main,release:noble:main,staging/master:focal:main,staging/master:jammy:main,staging/master:noble:main,staging-proprietary:bionic:main,staging-proprietary:disco:main,staging-proprietary:eoan:main,staging-proprietary:focal:main,staging-proprietary:groovy:main,staging-proprietary:hirsute:main,staging-proprietary:impish:main,staging-proprietary:jammy:main,staging-proprietary:noble:main"
+    repo: "proprietary:bionic:main,proprietary:disco:main,proprietary:eoan:main,proprietary:focal:main,proprietary:groovy:main,proprietary:hirsute:main,proprietary:impish:main,proprietary:jammy:main,proprietary:noble:main,proprietary:resolute:main,release:impish:main,release:jammy:main,release:noble:main,release:resolute:main,staging/master:jammy:main,staging/master:noble:main,staging/master:resolute:main,staging-proprietary:bionic:main,staging-proprietary:disco:main,staging-proprietary:eoan:main,staging-proprietary:focal:main,staging-proprietary:groovy:main,staging-proprietary:hirsute:main,staging-proprietary:impish:main,staging-proprietary:jammy:main,staging-proprietary:noble:main,staging-proprietary:resolute:main"
     interval: 10601
     path: /srv/data55T/pop-os
     name: pop-os

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -381,13 +381,12 @@ repos:
     rsync_extra_flags: --exclude "termux-main-21"
     <<:
       - *oneshot_common
-  # ubuntu
+  #ubuntu
   - type: external
-    script: /worker-script/ubuntu-debian-rsync.sh
-    source: rsync://rsync.archive.ubuntu.com/ubuntu/
-    interval: 24900
-    path: /srv/data55T/ubuntu
     name: ubuntu
+    serve_mode: redir
+    target: "{scheme}://ftp.sjtu.edu.cn/ubuntu/"
+    no_redir_http: true
     <<:
       - *oneshot_common
   # ubuntu-releases

--- a/config.siyuan.yaml
+++ b/config.siyuan.yaml
@@ -483,12 +483,12 @@ repos:
       - *oneshot_common
   # flutter_infra
   - type: shell_script
-    script: /worker-script/mirror-clone-v2.sh --workers 4 --target-type s3 --s3-prefix flutter_infra --s3-buffer-path /var/cache --print-plan 100 --no-delete rsync --http-base https://mirrors.tuna.tsinghua.edu.cn/flutter/flutter_infra --rsync-base rsync://mirrors.tuna.tsinghua.edu.cn/flutter/flutter_infra/
+    script: /worker-script/mirror-clone-v2.sh --workers 4 --target-type s3 --s3-prefix flutter_infra --s3-buffer-path /var/cache --print-plan 100 --no-delete rsync --http-base https://mirror.nju.edu.cn/flutter/flutter_infra --rsync-base rsync://mirror.nju.edu.cn/flutter/flutter_infra/
     serve_mode: mirror_intel
     interval: 4000
     name: flutter_infra
     # Note: this source is only used for mirrorz to have correct source info in mirrorz.json. If you want to change upstream, also change the upstream in mirror-clone command.
-    source: https://mirrors.tuna.tsinghua.edu.cn/flutter/flutter_infra
+    source: https://mirror.nju.edu.cn/flutter/flutter_infra
     <<:
       - *oneshot_common
   # ghcup

--- a/config.zhiyuan.yaml
+++ b/config.zhiyuan.yaml
@@ -292,6 +292,7 @@ repos:
     interval: 7200
     path: /mnt/linuxliteos
     name: linuxliteos
+    rsync_extra_flags: --exclude "/isos/**/*.iso.torrent"
     <<:
       - *oneshot_common
   # - type: shell_script

--- a/devshell.toml
+++ b/devshell.toml
@@ -22,7 +22,6 @@ programs = [
 
 # Pre-commit Hooks
 [pre-commit]
-flake-check = false
 package = "prek" # One of pre-commit, prek
 hooks = [
   "commitizen",

--- a/docker-compose.siyuan.yml
+++ b/docker-compose.siyuan.yml
@@ -121,11 +121,11 @@ networks:
     driver_opts:
       com.docker.network.driver.mtu: 1450
   ipv6-service-net:
-    enable_ipv6: true
+    enable_ipv6: false
     driver: bridge
     ipam:
       driver: default
       config:
-        - subnet: fd01::/80
+        - subnet: 172.30.0.0/16
     driver_opts:
       com.docker.network.driver.mtu: 1450

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       context: ./mirror-intel
       args:
         - USE_SJTUG=true
-        - INTEL_VERSION=v0.1.37
+        - INTEL_VERSION=v0.1.39
     networks:
       - ipv6-service-net
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,13 @@ services:
     expose:
       - 3000
     healthcheck:
-      test: curl -f http://localhost:3000 || exit 1
+      # `node:24-alpine` image includes `wget` but no `curl`
+      test: wget --spider -q http://localhost:3000 || exit 1
       interval: 1m30s
       timeout: 10s
       retries: 3
       start_period: 40s
+    stop_grace_period: 15s
     logging:
       options:
         max-size: "4M"
@@ -73,7 +75,6 @@ services:
       context: ./lug
       args:
         - USE_SJTUG=true
-        - CLONE_VERSION=v0.1.19
         - CLONE_V2_VERSION=v0.2.41
         - RSYNC_SJTUG_VERSION=v0.4.18
         - LUG_VERSION=v0.12.11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,8 @@ services:
       context: ./lug
       args:
         - USE_SJTUG=true
-        - CLONE_V2_VERSION=v0.2.41
-        - RSYNC_SJTUG_VERSION=v0.4.18
+        - CLONE_V2_VERSION=v0.2.42
+        - RSYNC_SJTUG_VERSION=v0.4.19
         - LUG_VERSION=v0.12.11
     expose:
       - 8081
@@ -119,7 +119,7 @@ services:
       context: ./rsync-gateway
       args:
         - USE_SJTUG=true
-        - RSYNC_SJTUG_VERSION=v0.4.18
+        - RSYNC_SJTUG_VERSION=v0.4.19
     networks:
       - ipv6-service-net
       - postgres-net
@@ -232,7 +232,7 @@ services:
       context: ./mirror-intel
       args:
         - USE_SJTUG=true
-        - INTEL_VERSION=v0.1.39
+        - INTEL_VERSION=v0.1.40
     networks:
       - ipv6-service-net
     expose:

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,25 @@
               enable = true;
             });
 
+          generated-file-checks = {
+            caddy-gen-check = {
+              enable = true;
+              name = "Caddyfiles up-to-date";
+              entry = "${lib.getExe pkgs.bash} -c 'CADDY_GEN_PYTHON=${mkVirtualenv "caddy-gen"}/bin/python exec ${lib.getExe pkgs.bash} ${./scripts/pre-commit/caddy-gen.sh}'";
+              language = "system";
+              pass_filenames = false;
+              files = "^(config\\.(siyuan|zhiyuan)\\.yaml|caddy-gen/src/)";
+            };
+            gateway-gen-check = {
+              enable = true;
+              name = "Gateway configs up-to-date";
+              entry = "${lib.getExe pkgs.bash} -c 'GATEWAY_GEN_PYTHON=${mkVirtualenv "gateway-gen"}/bin/python exec ${lib.getExe pkgs.bash} ${./scripts/pre-commit/gateway-gen.sh}'";
+              language = "system";
+              pass_filenames = false;
+              files = "^(config\\.(siyuan|zhiyuan)\\.yaml|gateway-gen/src/)";
+            };
+          };
+
           workspaces = lib.genAttrs workspaceNames (
             name: uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./. + "/${name}"; }
           );
@@ -171,19 +190,17 @@
             programs = enableAll cfg.treefmt.programs;
           };
 
-          pre-commit = {
-            check.enable = cfg.pre-commit.flake-check;
-            settings = {
-              configPath = ".pre-commit-config.flake.yaml";
-              package = pkgs.${cfg.pre-commit.package};
-              hooks = enableAll cfg.pre-commit.hooks;
-            };
+          pre-commit.settings = {
+            package = pkgs.${cfg.pre-commit.package};
+            configPath = ".pre-commit-config.flake.yaml";
+            hooks = (enableAll cfg.pre-commit.hooks) // generated-file-checks;
           };
 
           devShells = {
             default = pkgs.mkShellNoCC {
               inputsFrom = [
                 config.treefmt.build.devShell
+                config.pre-commit.devShell
               ];
             };
           }

--- a/flake.nix
+++ b/flake.nix
@@ -36,18 +36,8 @@
   };
 
   outputs =
-    inputs@{
-      self,
-      nixpkgs,
-      flake-parts,
-      pyproject-nix,
-      uv2nix,
-      uv2nix_hammer_overrides,
-      pyproject-build-systems,
-      pre-commit-hooks,
-      treefmt-nix,
-    }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.treefmt-nix.flakeModule
         inputs.pre-commit-hooks.flakeModule
@@ -64,125 +54,113 @@
           config,
           pkgs,
           lib,
-          system,
           ...
         }:
         let
-          buildSystemOverrides = {
-            loguru = {
-              flit-core = [ ];
-            };
-          };
+          inherit (inputs)
+            pyproject-build-systems
+            pyproject-nix
+            uv2nix
+            uv2nix_hammer_overrides
+            ;
 
           cfg = lib.importTOML ./devshell.toml;
+          workspaceNames = cfg.python.workspaces;
 
-          names = cfg.python.workspaces;
+          buildSystemOverrides = {
+            loguru.flit-core = [ ];
+          };
 
-          # Load a uv workspace from a workspace root.
-          # Uv2nix treats all uv projects as workspace projects.
-          workspaces = lib.foldl' (
-            acc: path:
-            acc
-            // {
-              "workspace-${path}" = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./. + "/${path}"; };
-            }
-          ) { } names;
+          enableAll =
+            names:
+            lib.genAttrs names (_: {
+              enable = true;
+            });
+
+          workspaces = lib.genAttrs workspaceNames (
+            name: uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./. + "/${name}"; }
+          );
 
           python =
             pkgs."python${lib.versions.major cfg.python.version}${lib.versions.minor cfg.python.version}";
 
           pyprojectOverrides = lib.composeExtensions (uv2nix_hammer_overrides.overrides pkgs) (
-            # use uv2nix_hammer_overrides.overrides_debug
-            #   to see which versions were matched to which overrides
-            #  use uv2nix_hammer_overrides.overrides_strict / overrides_strict_debug
-            #  to use only overrides exactly matching your python package versions
-
-            # Build system dependencies specified in the shape expected by resolveBuildSystem
-            # The empty lists below are lists of optional dependencies.
-            #
-            # A package `foo` with specification written as:
-            # `setuptools-scm[toml]` in pyproject.toml would be written as
-            # `foo.setuptools-scm = [ "toml" ]` in Nix
             final: prev:
-            let
-              inherit (final) resolveBuildSystem;
-              inherit (builtins) mapAttrs;
-              inherit buildSystemOverrides;
-            in
-            mapAttrs (
+            lib.mapAttrs (
               name: spec:
               prev.${name}.overrideAttrs (old: {
-                nativeBuildInputs = old.nativeBuildInputs ++ resolveBuildSystem spec;
+                nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ final.resolveBuildSystem spec;
               })
             ) buildSystemOverrides
           );
 
-          # Construct package set
-          pythonSet' = lib.foldl' (
-            acc: path:
-            acc
-            // {
-              "${path}" =
-                # Use base package set from pyproject.nix builders
-                (pkgs.callPackage pyproject-nix.build.packages {
-                  inherit python;
-                }).overrideScope
-                  (
-                    lib.composeManyExtensions [
-                      pyproject-build-systems.overlays.default
-                      (workspaces."workspace-${path}".mkPyprojectOverlay {
-                        # Prefer prebuilt binary wheels as a package source.
-                        # Sdists are less likely to "just work" because of the metadata missing from uv.lock.
-                        # Binary wheels are more likely to, but may still require overrides for library dependencies.
-                        sourcePreference = "wheel";
-                      })
-                      pyprojectOverrides
-                    ]
-                  );
-            }
-          ) { } names;
+          basePythonSet = pkgs.callPackage pyproject-nix.build.packages {
+            inherit python;
+          };
 
-          editablePythonSet = lib.foldl' (
-            acc: path:
-            acc
-            // {
-              "${path}" = pythonSet'.${path}.overrideScope (
-                lib.composeExtensions
-                  (workspaces."workspace-${path}".mkEditablePyprojectOverlay {
-                    root = "$REPO_ROOT";
-                  })
-                  (
-                    _final: prev: {
-                      "${path}" = prev.${path}.overrideAttrs (old: {
-                        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-                          _final.editables
-                        ];
-                      });
-                    }
-                  )
-              );
-            }
-          ) { } names;
-          virtualenv-dev =
+          pythonSets = lib.genAttrs workspaceNames (
             name:
-            editablePythonSet.${name}.mkVirtualEnv "${name}-dev-env" workspaces."workspace-${name}".deps.all;
+            basePythonSet.overrideScope (
+              lib.composeManyExtensions [
+                pyproject-build-systems.overlays.default
+                (workspaces.${name}.mkPyprojectOverlay {
+                  sourcePreference = "wheel";
+                })
+                pyprojectOverrides
+              ]
+            )
+          );
 
-          pythonSet = lib.foldl' (
-            acc: path:
-            acc
-            // {
-              "${path}" = pythonSet'.${path}.pythonPkgsHostHost.overrideScope pyprojectOverrides;
-            }
-          ) { } names;
-          virtualenv =
-            name: pythonSet.${name}.mkVirtualEnv "${name}-env" workspaces."workspace-${name}".deps.default;
+          editablePythonSets = lib.genAttrs workspaceNames (
+            name:
+            pythonSets.${name}.overrideScope (
+              lib.composeExtensions
+                (workspaces.${name}.mkEditablePyprojectOverlay {
+                  root = "$REPO_ROOT";
+                })
+                (
+                  final: prev: {
+                    "${name}" = prev.${name}.overrideAttrs (old: {
+                      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+                        final.editables
+                      ];
+                    });
+                  }
+                )
+            )
+          );
 
-          inherit (pkgs.callPackages pyproject-nix.build.util { }) mkApplication;
+          runtimePythonSets = lib.genAttrs workspaceNames (
+            name: pythonSets.${name}.pythonPkgsHostHost.overrideScope pyprojectOverrides
+          );
 
+          mkDevVirtualenv =
+            name: editablePythonSets.${name}.mkVirtualEnv "${name}-dev-env" workspaces.${name}.deps.all;
+
+          mkVirtualenv =
+            name: runtimePythonSets.${name}.mkVirtualEnv "${name}-env" workspaces.${name}.deps.default;
+
+          mkWorkspaceShell =
+            name:
+            pkgs.mkShell {
+              nativeBuildInputs = [
+                (mkDevVirtualenv name)
+                pkgs.uv
+              ];
+
+              env = {
+                UV_NO_SYNC = "1";
+                UV_PYTHON = editablePythonSets.${name}.python.interpreter;
+                UV_PYTHON_DOWNLOADS = "never";
+              };
+
+              shellHook = ''
+                unset PYTHONPATH
+                export REPO_ROOT=$(git rev-parse --show-toplevel)/${name}
+              '';
+            };
         in
         {
-          # https://flake.parts/options/treefmt-nix.html
-          # Example: https://github.com/nix-community/buildbot-nix/blob/main/nix/treefmt/flake-module.nix
           treefmt = {
             projectRootFile = ".git/config";
             flakeCheck = cfg.treefmt.flake-check;
@@ -190,71 +168,28 @@
               "rsync-gateway/config.*.toml"
             ];
 
-            programs = builtins.listToAttrs (
-              map (x: {
-                name = x;
-                value = {
-                  enable = true;
-                };
-              }) cfg.treefmt.programs
-            );
+            programs = enableAll cfg.treefmt.programs;
           };
 
-          # https://flake.parts/options/git-hooks-nix.html
-          # Example: https://github.com/cachix/git-hooks.nix/blob/master/template/flake.nix
-          pre-commit.check.enable = cfg.pre-commit.flake-check;
-          pre-commit.settings.configPath = ".pre-commit-config.flake.yaml";
-          pre-commit.settings.package = pkgs.${cfg.pre-commit.package};
-          pre-commit.settings.hooks = builtins.listToAttrs (
-            map (x: {
-              name = x;
-              value = {
-                enable = true;
-              };
-            }) cfg.pre-commit.hooks
-          );
+          pre-commit = {
+            check.enable = cfg.pre-commit.flake-check;
+            settings = {
+              configPath = ".pre-commit-config.flake.yaml";
+              package = pkgs.${cfg.pre-commit.package};
+              hooks = enableAll cfg.pre-commit.hooks;
+            };
+          };
 
-          # Create a development shell containing dependencies from `pyproject.toml`
           devShells = {
             default = pkgs.mkShellNoCC {
               inputsFrom = [
                 config.treefmt.build.devShell
-                # config.pre-commit.devShell
               ];
             };
           }
-          // (lib.foldl' (
-            acc: name:
-            acc
-            // {
-              "${name}" = pkgs.mkShell {
-                nativeBuildInputs = [
-                  (virtualenv-dev name)
-                  pkgs.uv
-                ];
+          // lib.genAttrs workspaceNames mkWorkspaceShell;
 
-                env = {
-                  UV_NO_SYNC = "1";
-                  UV_PYTHON = editablePythonSet.${name}.python.interpreter;
-                  UV_PYTHON_DOWNLOADS = "never";
-                };
-
-                shellHook = ''
-                  unset PYTHONPATH
-                  export REPO_ROOT=$(git rev-parse --show-toplevel)/${name}
-                '';
-              };
-            }
-          ) { } names);
-
-          packages = lib.foldl' (
-            acc: name:
-            acc
-            // {
-              "${name}" = virtualenv name;
-            }
-          ) { } names;
-
+          packages = lib.genAttrs workspaceNames mkVirtualenv;
         };
     };
 }

--- a/lug/Dockerfile
+++ b/lug/Dockerfile
@@ -71,13 +71,8 @@ RUN /app/build-script/from-cache.sh \
     tmp.tar.gz \
     && tar -xvf tmp.tar.gz && rm tmp.tar.gz
 
-ARG CLONE_VERSION
-RUN /app/build-script/from-cache.sh \
-    https://mirror.sjtu.edu.cn/sjtug-internal/mirror-clone/releases/download/${CLONE_VERSION}/mirror-clone.tar.gz \
-    https://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/sjtug-internal/mirror-clone/releases/download/${CLONE_VERSION}/mirror-clone.tar.gz \
-    https://github.com/sjtug/mirror-clone/releases/download/${CLONE_VERSION}/mirror-clone.tar.gz \
-    tmp.tar.gz \
-    && tar -xvf tmp.tar.gz && rm tmp.tar.gz
+# Legacy v1 mirror-clone removed — only usage (pytorch-wheels) migrated
+# to on-demand mirror-intel proxy. v2 binary is in /app/v2/mirror-clone.
 
 ARG CLONE_V2_VERSION
 RUN mkdir v2 && cd v2 && /app/build-script/from-cache.sh \

--- a/lug/worker-script/zhiyuan/worker-script/pre-git.sh
+++ b/lug/worker-script/zhiyuan/worker-script/pre-git.sh
@@ -8,7 +8,15 @@ fi
 
 cd "$LUG_path"
 git remote set-url origin "$LUG_origin"
-git pull --all --rebase || (git reset --hard origin/HEAD && git pull --all --rebase)
+git fetch --prune origin
+git remote set-head origin --auto
+
+origin_head="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD)"
+default_branch="${origin_head#origin/}"
+
+git checkout -B "$default_branch" "$origin_head"
+git branch --set-upstream-to="$origin_head" "$default_branch"
+git reset --hard "$origin_head"
 git update-server-info
 git gc --auto
 git repack -a -b -d

--- a/rsync-gateway/config.siyuan.toml
+++ b/rsync-gateway/config.siyuan.toml
@@ -27,11 +27,6 @@ namespace = "alhp"
 s3_bucket = "899a892efef34b1b944a19981040f55b-oss01"
 s3_prefix = "rsync/alhp"
 
-[endpoints.nspawn]
-namespace = "nspawn"
-s3_bucket = "899a892efef34b1b944a19981040f55b-oss01"
-s3_prefix = "rsync/nspawn"
-
 [endpoints.leopardsh]
 namespace = "leopardsh"
 s3_bucket = "899a892efef34b1b944a19981040f55b-oss01"

--- a/scripts/pre-commit/caddy-gen.sh
+++ b/scripts/pre-commit/caddy-gen.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Pre-commit hook: verify generated Caddyfiles are up-to-date with their sources.
+#
+# Regenerates caddy-gen output to a temporary directory and diffs each file
+# against the tracked versions in caddy/.  Exits 1 (blocking commit) when
+# any generated file is stale.
+#
+# The script is idempotent and leaves the working tree untouched.
+
+set -o errexit -o nounset -o pipefail
+
+SELF_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+if [[ -f "$PWD/flake.nix" && -d "$PWD/caddy-gen" ]]; then
+  PROJECT_DIR=$PWD
+else
+  PROJECT_DIR=$(cd -- "$SELF_DIR/../.." && pwd)
+fi
+
+cd "$PROJECT_DIR"
+
+# ---- helpers ----------------------------------------------------------------
+
+RED=; GREEN=; BOLD=; RESET=
+if [[ -t 2 ]] && command -v tput >/dev/null 2>&1; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  BOLD=$(tput bold)
+  RESET=$(tput sgr0)
+fi
+
+die()   { echo "${RED}${BOLD}ERROR${RESET}${BOLD}: $*${RESET}" >&2; exit 1; }
+ok()    { echo "  ${GREEN}ok${RESET}  $*"; }
+fail()  { echo "  ${RED}FAIL${RESET} $*"; }
+
+# ---- config -----------------------------------------------------------------
+
+SITES=(siyuan zhiyuan)
+
+# Relative to PROJECT_DIR
+GENERATOR_DIR="caddy-gen"
+GENERATOR_SCRIPT="src/caddy-gen.py"
+INPUT_DIR="."
+OUTPUT_DIR="caddy"
+
+GENERATED_FILES=()
+for site in "${SITES[@]}"; do
+  GENERATED_FILES+=("$OUTPUT_DIR/Caddyfile.$site")
+done
+
+# ---- bootstrap venv ---------------------------------------------------------
+
+CADDY_GEN_PYTHON=${CADDY_GEN_PYTHON:-}
+if [[ -z "$CADDY_GEN_PYTHON" ]]; then
+  echo ":: Setting up Python virtual environment (if needed)..."
+  make configure-venv >/dev/null 2>&1 || die "make configure-venv failed"
+  CADDY_GEN_PYTHON="$PROJECT_DIR/$GENERATOR_DIR/.venv/bin/python"
+fi
+
+[[ -x "$CADDY_GEN_PYTHON" ]] || die "Python interpreter not found: $CADDY_GEN_PYTHON"
+
+# ---- regenerate to temp dir -------------------------------------------------
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo ":: Regenerating Caddyfiles..."
+# Build site list: "siyuan,zhiyuan"
+SITE_LIST=$(IFS=,; echo "${SITES[*]}")
+
+cd "$GENERATOR_DIR"
+"$CADDY_GEN_PYTHON" "$GENERATOR_SCRIPT" \
+  -i "$PROJECT_DIR/$INPUT_DIR" \
+  -o "$TMPDIR" \
+  --site "$SITE_LIST" \
+  >/dev/null 2>&1 || die "caddy-gen failed"
+cd "$PROJECT_DIR"
+
+# ---- diff each generated file -----------------------------------------------
+
+ANY_FAILURE=0
+
+for site in "${SITES[@]}"; do
+  tracked="$PROJECT_DIR/$OUTPUT_DIR/Caddyfile.$site"
+  generated="$TMPDIR/Caddyfile.$site"
+
+  if [[ ! -f "$generated" ]]; then
+    fail "$tracked — generator did not produce this file"
+    ANY_FAILURE=1
+    continue
+  fi
+
+  if diff -q "$tracked" "$generated" >/dev/null 2>&1; then
+    ok "$tracked"
+  else
+    fail "$tracked — file is stale, run 'make caddy-gen' to regenerate"
+    ANY_FAILURE=1
+  fi
+done
+
+echo ""
+if [[ $ANY_FAILURE -eq 0 ]]; then
+  echo "${GREEN}All Caddyfiles are up-to-date.${RESET}"
+  exit 0
+else
+  echo "${RED}${BOLD}Some generated files are stale.  Run 'make caddy-gen' and commit the updated files.${RESET}"
+  exit 1
+fi

--- a/scripts/pre-commit/gateway-gen.sh
+++ b/scripts/pre-commit/gateway-gen.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Pre-commit hook: verify generated rsync-gateway configs are up-to-date with
+# their sources.
+#
+# Regenerates gateway-gen output to a temporary directory and diffs each file
+# against the tracked versions in rsync-gateway/.  Exits 1 (blocking commit)
+# when any generated file is stale.
+#
+# The script is idempotent and leaves the working tree untouched.
+
+set -o errexit -o nounset -o pipefail
+
+SELF_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+if [[ -f "$PWD/flake.nix" && -d "$PWD/gateway-gen" ]]; then
+  PROJECT_DIR=$PWD
+else
+  PROJECT_DIR=$(cd -- "$SELF_DIR/../.." && pwd)
+fi
+
+cd "$PROJECT_DIR"
+
+# ---- helpers ----------------------------------------------------------------
+
+RED=; GREEN=; BOLD=; RESET=
+if [[ -t 2 ]] && command -v tput >/dev/null 2>&1; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  BOLD=$(tput bold)
+  RESET=$(tput sgr0)
+fi
+
+die()   { echo "${RED}${BOLD}ERROR${RESET}${BOLD}: $*${RESET}" >&2; exit 1; }
+ok()    { echo "  ${GREEN}ok${RESET}  $*"; }
+fail()  { echo "  ${RED}FAIL${RESET} $*"; }
+
+# ---- config -----------------------------------------------------------------
+
+SITES=(siyuan zhiyuan)
+
+# Relative to PROJECT_DIR
+GENERATOR_DIR="gateway-gen"
+GENERATOR_SCRIPT="src/gateway-gen.py"
+INPUT_DIR="."
+OUTPUT_DIR="rsync-gateway"
+
+# ---- bootstrap venv ---------------------------------------------------------
+
+GATEWAY_GEN_PYTHON=${GATEWAY_GEN_PYTHON:-}
+if [[ -z "$GATEWAY_GEN_PYTHON" ]]; then
+  echo ":: Setting up Python virtual environment (if needed)..."
+  make configure-venv >/dev/null 2>&1 || die "make configure-venv failed"
+  GATEWAY_GEN_PYTHON="$PROJECT_DIR/$GENERATOR_DIR/.venv/bin/python"
+fi
+
+[[ -x "$GATEWAY_GEN_PYTHON" ]] || die "Python interpreter not found: $GATEWAY_GEN_PYTHON"
+
+# ---- regenerate to temp dir -------------------------------------------------
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo ":: Regenerating rsync-gateway configs..."
+SITE_LIST=$(IFS=,; echo "${SITES[*]}")
+
+cd "$GENERATOR_DIR"
+"$GATEWAY_GEN_PYTHON" "$GENERATOR_SCRIPT" \
+  -i "$PROJECT_DIR/$INPUT_DIR" \
+  -o "$TMPDIR" \
+  --site "$SITE_LIST" \
+  >/dev/null 2>&1 || die "gateway-gen failed"
+cd "$PROJECT_DIR"
+
+# ---- diff each generated file -----------------------------------------------
+
+ANY_FAILURE=0
+
+for site in "${SITES[@]}"; do
+  tracked="$PROJECT_DIR/$OUTPUT_DIR/config.$site.toml"
+  generated="$TMPDIR/config.$site.toml"
+
+  if [[ ! -f "$generated" ]]; then
+    fail "$tracked — generator did not produce this file"
+    ANY_FAILURE=1
+    continue
+  fi
+
+  if diff -q "$tracked" "$generated" >/dev/null 2>&1; then
+    ok "$tracked"
+  else
+    fail "$tracked — file is stale, run 'make gateway-gen' to regenerate"
+    ANY_FAILURE=1
+  fi
+done
+
+echo ""
+if [[ $ANY_FAILURE -eq 0 ]]; then
+  echo "${GREEN}All rsync-gateway configs are up-to-date.${RESET}"
+  exit 0
+else
+  echo "${RED}${BOLD}Some generated files are stale.  Run 'make gateway-gen' and commit the updated files.${RESET}"
+  exit 1
+fi


### PR DESCRIPTION
Changes:
 - lug(linuxliteos): exclude torrents
 - lug: drop tldp, nspawn due to inactive upstream
 - bump: add pop-os 26.04 "resolute"
 - fix(flutter_infra): update upstream
 - lug: fix Git worker script to track remote
 - chore(nix): simplify flake.nix
 - bump: update frontend
 - Revert "lug(ubuntu): serve on local storage"
 - fix: replace IPv6-only upstreams; drop IPv6 subnet
 - pytorch-wheels: drop legacy mirror-clone
 - frontend: fix healthcheck, add exit handler

TODOs:

- [x] bump tools to latest version
- [ ] update release CI for mirror-intel/mirror-clone
- [ ] refactor with nix2container/nix-snapshotter