### PR TITLE
fix(git-backend): relax fastcgi worker param

### DIFF
--- a/git-backend/Dockerfile
+++ b/git-backend/Dockerfile
@@ -52,5 +52,5 @@ RUN git config --global pack.threads 4 \
     && git config --global core.bare true
 
 
-CMD spawn-fcgi -s /run/fcgi.sock /usr/sbin/fcgiwrap && \
+CMD spawn-fcgi -s /run/fcgi.sock -F 8 /usr/sbin/fcgiwrap && \
     nginx -g "daemon off;"

--- a/git-backend/nginx.conf
+++ b/git-backend/nginx.conf
@@ -30,6 +30,10 @@ http {
             # Set chunks to unlimited, as the bodies can be huge
             client_max_body_size            0;
 
+            fastcgi_read_timeout    600;
+            fastcgi_send_timeout    600;
+            fastcgi_connect_timeout 60;
+
             fastcgi_param SCRIPT_FILENAME /usr/lib/git-core/git-http-backend;
             include fastcgi_params;
             fastcgi_param GIT_HTTP_EXPORT_ALL "";


### PR DESCRIPTION
- spawn multiple fcgiwrap workers to prevent parallel Git requests from blocking
- extend fastcgi timeout to 600s (might be unnecessary except for bad connectivity)